### PR TITLE
feat: Add support for named exports

### DIFF
--- a/example/src/Button.tsx
+++ b/example/src/Button.tsx
@@ -45,11 +45,11 @@ const variantStyles: Record<NonNullable<ButtonProps['variant']>, React.CSSProper
 /**
  * A simple button component for demonstration purposes.
  */
-export default function Button({
+export const Button = ({
   label,
   variant = 'contained',
   disabled = false,
-}: ButtonProps) {
+}: ButtonProps) => {
   const style = {
     ...baseStyles,
     ...variantStyles[variant],
@@ -62,4 +62,17 @@ export default function Button({
       {label}
     </button>
   );
+};
+
+type IconButtonProps = {
+    icon: string;
+    onClick: () => void;
+}
+
+export const IconButton = ({ icon, onClick }: IconButtonProps) => {
+    return (
+        <button onClick={onClick} style={{ background: 'none', border: 'none', cursor: 'pointer' }}>
+            <span className="material-icons">{icon}</span>
+        </button>
+    )
 }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin, ViteDevServer } from 'vite';
 import path from 'path';
-import { createScanner, Manifest, Scanner } from './scanner';
+import { createScanner, Manifest, Scanner } from './scanner.js';
 
 const VIRTUAL_MODULE_ID = 'virtual:rplite-manifest';
 const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;

--- a/packages/plugin/tsconfig.json
+++ b/packages/plugin/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "noEmit": false
+    "noEmit": false,
+    "module": "esnext",
+    "moduleResolution": "node"
   },
   "include": ["src"],
   "references": []

--- a/packages/runtime/src/playground/Preview.tsx
+++ b/packages/runtime/src/playground/Preview.tsx
@@ -53,7 +53,7 @@ export function Preview({ component, props }: PreviewProps) {
       iframeRef.current.contentWindow.postMessage(
         {
           type: 'rplite-render',
-          componentPath: `/${component.path}`,
+          component,
           props,
         },
         '*'

--- a/packages/runtime/src/playground/iframeClient.ts
+++ b/packages/runtime/src/playground/iframeClient.ts
@@ -5,11 +5,11 @@ let root = createRoot(document.getElementById('root')!);
 
 window.addEventListener('message', async (event) => {
   if (event.data.type === 'rplite-render') {
-    const { componentPath, props } = event.data;
+    const { component, props } = event.data;
     try {
-      // The vite dev server will resolve this absolute path
+      const componentPath = `/${component.path}`;
       const CompModule = await import(/* @vite-ignore */ componentPath);
-      const Component = CompModule.default;
+      const Component = component.isDefaultExport ? CompModule.default : CompModule[component.name];
 
       if (Component) {
         const element = React.createElement(Component, props);


### PR DESCRIPTION
This commit enhances `react-playground-lite` to discover and render React components that are exported using named exports, in addition to the existing support for default exports.

The key changes are:
- The component scanner (`@rplite/plugin`) is updated to iterate through all exports of a module and identify functions that are React components.
- The `ComponentDef` type is updated with an `isDefaultExport` flag to distinguish between default and named exports.
- The Playground UI (`@rplite/runtime`) is updated to handle the selection and display of components with named exports. The sidebar now displays components in the format `FileName / ComponentName` for named exports.
- The preview iframe is updated to dynamically import either the default export or a named export from a module.
- The example application is updated to use named exports and includes a second component to demonstrate the new functionality.